### PR TITLE
Departure and Arrival time added to GetRoute.js

### DIFF
--- a/src/components/pages/GetRoute.js
+++ b/src/components/pages/GetRoute.js
@@ -16,6 +16,7 @@ function GetRoute(props) {
   const [origin, setOrigin] = useState('atlanta');
   const [destination, setDestination] = useState('norcross');
   const [travelMode, setTravelMode] = useState('TRANSIT');
+  const [transitOptions, setTransitOptions] = useState({});
 
   // Autocomplete useStates and useRefs
   const [showOriginDropdown, setShowOriginDropdown] = useState(false);
@@ -54,12 +55,46 @@ function GetRoute(props) {
   const onTravelModeChange = (event) => {
     setTravelMode(event.target.value);
   };
+  const onDepartureTimeChange = (event) => {
+    let today = new Date();
+    let departure = {};
+    if (event.target.value !== '') {
+      // Update current date object with user entered departureTime
+      today.setHours(event.target.value.substring(0, 2));
+      today.setMinutes(event.target.value.substring(3, 5));
+      departure = { departureTime: today };
+    } else {
+      departure = { departureTime: null };
+    }
+    setTransitOptions({
+      ...transitOptions,
+      ...departure,
+    });
+  };
+  const onArrivalTimeChange = (event) => {
+    let today = new Date();
+    let arrival = {};
+    console.log(event.target.value);
+    if (event.target.value !== '') {
+      // Update current date object with user entered arrivalTime
+      today.setHours(event.target.value.substring(0, 2));
+      today.setMinutes(event.target.value.substring(3, 5));
+      arrival = { arrivalTime: today };
+    } else {
+      arrival = { arrivalTime: null };
+    }
+    setTransitOptions({
+      ...transitOptions,
+      ...arrival,
+    });
+  };
   const onSubmitDirections = () => {
     if (origin && destination) {
       setDirectionsRequest({
         origin,
         destination,
         travelMode,
+        transitOptions,
       });
     }
   };
@@ -68,10 +103,11 @@ function GetRoute(props) {
     <div className='routeForms'>
       <h2>FIND A ROUTE</h2>
       <div className='fieldWrapper'>
+        <label htmlFor='from'>Origin </label>
         <input
           type='text'
           id='from'
-          placeholder='origin'
+          placeholder='enter address'
           value={origin}
           onChange={onOriginChange}
           onFocus={() => setShowOriginDropdown(true)}
@@ -106,10 +142,11 @@ function GetRoute(props) {
         )}
       </div>
       <div className='fieldWrapper'>
+        <label htmlFor='dest'>Destination </label>
         <input
           type='text'
           id='dest'
-          placeholder='origin'
+          placeholder='enter address'
           value={destination}
           onChange={onDestinationChange}
           onFocus={() => setShowDestDropdown(true)}
@@ -143,7 +180,12 @@ function GetRoute(props) {
           </div>
         )}
       </div>
-      <b>Select type of Commute</b>
+      {/* TODO: Create Departure/Arrival Time input fields */}
+      <label htmlFor='depart'>Departure Time </label>
+      <input type='time' id='depart' onChange={onDepartureTimeChange}></input>
+      <label htmlFor='arrive'>Arrival Time </label>
+      <input type='time' id='arrive' onChange={onArrivalTimeChange}></input>
+      <b>Select type of Commute </b>
       <select id='mode' value={travelMode} onChange={onTravelModeChange}>
         <option value='DRIVING'>Driving</option>
         <option value='WALKING'>Walking</option>

--- a/src/components/pages/Schedule.js
+++ b/src/components/pages/Schedule.js
@@ -1,0 +1,4 @@
+const Schedule = () => {
+  return <div>Schedule</div>;
+};
+export default Schedule;


### PR DESCRIPTION
I've updated the GetRoute component to have optional Departure Time and Arrival Time fields. If left blank the route will calculate with the current time as before. Arrival time will always override Departure Time, even if both fields are used which is how Google's DirectionsRequest works by default anyway. It should be noted that for now Departure and Arrival only work for the transit travelMode. Driving will ignore Departure and Arrival completely. That should be a pretty simple fix later down the road though.
![Screenshot 2023-03-22 at 2 14 40 PM](https://user-images.githubusercontent.com/69475619/226999444-df499cc4-0f3c-4a5d-a835-cf31c71b8343.png)