### PR TITLE
User's scheduled routes now appear on the Profile page

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -220,12 +220,24 @@ def get_google_route():
     # print(get_route().text)
     return get_route()
 
-@app.route('/get_schedule')
+@app.route('/get_schedule', methods=['GET'])
+@jwt_required()
 def get_schedule():
-    ''' Grabs current user's schedule for the week.
-        Currently not implemented    
-    '''
-    return "PLACE HOLDER FOR GETTING USER SCHEDULE"
+    ''' Grabs current user's schedule for the week. '''
+    current_user = get_jwt_identity()
+    # current_user = "chart10"
+    cursor = mysql.connection.cursor()
+    cursor.execute('SELECT scheduledRoutes.routeID, dayOfWeek, travelMode, departArrive, timeOfDay, departAddress, arriveAddress FROM scheduledRoutes, scheduledRoutesDayOfWeek WHERE username = %s', (current_user,))
+    database_routes = cursor.fetchall()
+    schedule_result = []
+    for route in database_routes:
+        schedule_result.append(json.dumps(route,default=str))
+    # cursor.execute('SELECT dayOfWeek FROM scheduledRoutesDayOfWeek WHERE username = %s', (current_user,))
+    # routeDay_results = cursor.fetchall()
+    # print(routeDay_results)
+    # for route in 
+    response = {'schedule_result': schedule_result}
+    return response
 
 # Api Route to save scheduled direction parameters to user profile
 @app.route('/save_scheduled_directions', methods=['POST'])

--- a/api/api.py
+++ b/api/api.py
@@ -223,24 +223,50 @@ def get_google_route():
 @app.route('/get_schedule', methods=['GET'])
 @jwt_required()
 def get_schedule():
-    ''' Grabs current user's schedule for the week. '''
+    # Grabs current user's schedule for the week
     current_user = get_jwt_identity()
-    current_user = "chart10"
+    # current_user = "chart10"
+    
     cursor = mysql.connection.cursor()
+    
+    # Pull user's weekly schedule from db by joining scheduledRoutes and scheduledRoutesDayOfWeek
     cursor.execute('SELECT scheduledRoutes.routeID, dayOfWeek, travelMode, departArrive,' +
-                   'timeOfDay, departAddress, arriveAddress FROM scheduledRoutes INNER JOIN ' +
+                   'timeOfDay, origin, destination FROM scheduledRoutes INNER JOIN ' +
                    'scheduledRoutesDayOfWeek ON ' +
                    'scheduledRoutes.routeID=scheduledRoutesDayOfWeek.routeID ' +
                    'WHERE username = %s', (current_user,))
-    database_routes = cursor.fetchall()
-    schedule_result = []
-    # schedule_result = json.dumps(database_routes,default=str)
-    for route in database_routes:
-        schedule_result.append(json.dumps(route,default=str))
+    
+    # Convert query results into a frontend-friendly array of dictionaries
+    # First, get the names of all the columns in the query. These will be the keys
+    description = cursor.description
+    column_names = [column[0] for column in description]
+    
+    # Next, zip column_names with each row in the query result to get an array of dictionaries!
+    schedule_result = [dict(zip(column_names,row)) for row in cursor]
+    
+    # Last step, we need to convert the datetime saved by the db to a string so that it can be
+    # converted to JSON and read by the frontend
+    for route in schedule_result:
+        for key, value in route.items():
+            if (key == "timeOfDay"):
+                route[key] = ':'.join(str(value).split(':')[:2]) # I shaved off the seconds, fyi
 
-    print(json.dumps(database_routes,default=str))
-    response = json.dumps(database_routes,default=str)
-    return response
+
+    # database_routes = json.dumps(cursor.fetchall(),default=str)
+    
+    print(schedule_result)
+    # route_elements = ['routeID', 'dayOfWeek','travelMode', 'departArrive','timeOfDay',
+    #                   'departAddress', 'arriveAddress']
+    # This forloop will zip each array from database_routes with the keys from route_elements
+    # for route in database_routes:
+        # print(route)
+        # result_item = {}
+        # for key, value in zip(route_elements,route):
+        #     result_item[key] = value
+        #     print( result_item )
+            # schedule_result.append(result_item)
+    
+    return schedule_result
 
 # Api Route to save scheduled direction parameters to user profile
 @app.route('/save_scheduled_directions', methods=['POST'])
@@ -263,7 +289,7 @@ def save_scheduled_directions():
     
     # Input data into the scheduledRoutes table
     cursor.execute('INSERT INTO scheduledRoutes (username, travelMode, departArrive, timeOfDay,'+
-                   'departAddress, arriveAddress) VALUES(%s,%s,%s,%s,%s,%s)',
+                   'origin, destination) VALUES(%s,%s,%s,%s,%s,%s)',
                    (current_user, travelMode, departArrive, timeOfDay, origin, destination,))
     
     # Retrieve routeID of the just-saved directions

--- a/api/api.py
+++ b/api/api.py
@@ -225,18 +225,21 @@ def get_google_route():
 def get_schedule():
     ''' Grabs current user's schedule for the week. '''
     current_user = get_jwt_identity()
-    # current_user = "chart10"
+    current_user = "chart10"
     cursor = mysql.connection.cursor()
-    cursor.execute('SELECT scheduledRoutes.routeID, dayOfWeek, travelMode, departArrive, timeOfDay, departAddress, arriveAddress FROM scheduledRoutes, scheduledRoutesDayOfWeek WHERE username = %s', (current_user,))
+    cursor.execute('SELECT scheduledRoutes.routeID, dayOfWeek, travelMode, departArrive,' +
+                   'timeOfDay, departAddress, arriveAddress FROM scheduledRoutes INNER JOIN ' +
+                   'scheduledRoutesDayOfWeek ON ' +
+                   'scheduledRoutes.routeID=scheduledRoutesDayOfWeek.routeID ' +
+                   'WHERE username = %s', (current_user,))
     database_routes = cursor.fetchall()
     schedule_result = []
+    # schedule_result = json.dumps(database_routes,default=str)
     for route in database_routes:
         schedule_result.append(json.dumps(route,default=str))
-    # cursor.execute('SELECT dayOfWeek FROM scheduledRoutesDayOfWeek WHERE username = %s', (current_user,))
-    # routeDay_results = cursor.fetchall()
-    # print(routeDay_results)
-    # for route in 
-    response = {'schedule_result': schedule_result}
+
+    print(json.dumps(database_routes,default=str))
+    response = json.dumps(database_routes,default=str)
     return response
 
 # Api Route to save scheduled direction parameters to user profile

--- a/src/components/pages/Schedule.js
+++ b/src/components/pages/Schedule.js
@@ -3,6 +3,7 @@ import { useOutletContext } from 'react-router-dom';
 // eslint-disable-next-line no-unused-vars
 import axios from 'axios';
 import './pages.css';
+import ScheduleList from './ScheduleList';
 
 const Schedule = () => {
   const [addressData] = useOutletContext();
@@ -82,6 +83,7 @@ const Schedule = () => {
   return (
     <section id='scheduleSection'>
       <h2>Weekly Schedule</h2>
+      <ScheduleList />
       <ul id='weeklySchedule'></ul>
       <p>Add a route to your weekly schedule:</p>
       <input

--- a/src/components/pages/ScheduleList.js
+++ b/src/components/pages/ScheduleList.js
@@ -40,12 +40,12 @@ const ScheduleList = () => {
           <h3 className='weekday'>Monday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 0 ? (
+              route.dayOfWeek === 0 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -55,12 +55,12 @@ const ScheduleList = () => {
           <h3 className='weekday'>Tuesday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 1 ? (
+              route.dayOfWeek === 1 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -70,12 +70,12 @@ const ScheduleList = () => {
           <h3 className='weekday'>Wednesday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 2 ? (
+              route.dayOfWeek === 2 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -85,12 +85,12 @@ const ScheduleList = () => {
           <h3 className='weekday'>Thursday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 3 ? (
+              route.dayOfWeek === 3 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -100,12 +100,12 @@ const ScheduleList = () => {
           <h3 className='weekday'>Friday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 4 ? (
+              route.dayOfWeek === 4 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -115,12 +115,12 @@ const ScheduleList = () => {
           <h3>Saturday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 5 ? (
+              route.dayOfWeek === 5 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>
@@ -130,12 +130,12 @@ const ScheduleList = () => {
           <h3>Sunday</h3>
           <ul>
             {scheduledDirections.map((route, index) =>
-              route[1] === 6 ? (
+              route.dayOfWeek === 6 ? (
                 <li className='route' key={'route_' + index}>
-                  <p>Origin: {route[5]}</p>
-                  <p>Destination: {route[6]}</p>
+                  <p>Origin: {route.origin}</p>
+                  <p>Destination: {route.destination}</p>
                   <p>
-                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                    {route.departArrive} @ {route.timeOfDay}
                   </p>
                   <br />
                 </li>

--- a/src/components/pages/ScheduleList.js
+++ b/src/components/pages/ScheduleList.js
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { useOutletContext } from 'react-router-dom';
 import axios from 'axios';
 import './pages.css';
 
 const ScheduleList = () => {
   const [scheduledDirections, setScheduledDirecitons] = useState([]);
-  const [errorMessageSchedule, setErrorMessageSchedule] = useState('');
 
   // UseEffect that pulls user's scheduled directions from the database
   useEffect(() => {
@@ -19,12 +17,10 @@ const ScheduleList = () => {
     })
       .then((response) => {
         console.log(response);
-        setScheduledDirecitons(response.data.schedule_result);
-        setErrorMessageSchedule('SCHEDULE RETRIEVED!!');
+        setScheduledDirecitons(response.data);
       })
       .catch((error) => {
         if (error.response) {
-          setErrorMessageSchedule('FAILED TO RETRIEVE SCHEDULE! TRY AGAIN.');
           console.log(error.response);
           console.log(error.response.status);
           console.log(error.response.headers);
@@ -37,20 +33,112 @@ const ScheduleList = () => {
       {scheduledDirections === null ? (
         <p>You\'re weekly scheduled routes will appear here.</p>
       ) : (
-        <div>
-          <h2>SCHEDULE LIST GOES HERE</h2>
-          <h3>Monday</h3>
+        <div className='weeklySchedule'>
+          <h3 className='weekday'>Monday</h3>
           <ul>
-            {scheduledDirections.map((route, index) => (
-              <li key={'route_' + index}>{route}</li>
-            ))}
+            {scheduledDirections.map((route, index) =>
+              route[1] === 0 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
           </ul>
-          <h3>Tuesday</h3>
-          <h3>Wednesday</h3>
-          <h3>Thursday</h3>
-          <h3>Friday</h3>
+          <h3 className='weekday'>Tuesday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 1 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
+          <h3 className='weekday'>Wednesday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 2 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
+          <h3 className='weekday'>Thursday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 3 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
+          <h3 className='weekday'>Friday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 4 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
           <h3>Saturday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 5 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
           <h3>Sunday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) =>
+              route[1] === 6 ? (
+                <li className='route' key={'route_' + index}>
+                  <p>Origin: {route[5]}</p>
+                  <p>Destination: {route[6]}</p>
+                  <p>
+                    {route[3]} @ {route[4].slice(0, route[4].length - 3)}
+                  </p>
+                  <br />
+                </li>
+              ) : null
+            )}
+          </ul>
         </div>
       )}
     </>

--- a/src/components/pages/ScheduleList.js
+++ b/src/components/pages/ScheduleList.js
@@ -3,6 +3,9 @@ import axios from 'axios';
 import './pages.css';
 
 const ScheduleList = () => {
+  // scheduleDirections is an array of objects that represent saved routes
+  // route = { 'routeID': int, 'dayOfWeek': int, 'travelMode': string, 'departArrive': string,
+  // 'timeOfDay': hh:mm, 'origin': string, 'destination': string}
   const [scheduledDirections, setScheduledDirecitons] = useState([]);
 
   // UseEffect that pulls user's scheduled directions from the database

--- a/src/components/pages/ScheduleList.js
+++ b/src/components/pages/ScheduleList.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { useOutletContext } from 'react-router-dom';
+import axios from 'axios';
+import './pages.css';
+
+const ScheduleList = () => {
+  const [scheduledDirections, setScheduledDirecitons] = useState([]);
+  const [errorMessageSchedule, setErrorMessageSchedule] = useState('');
+
+  // UseEffect that pulls user's scheduled directions from the database
+  useEffect(() => {
+    axios({
+      method: 'GET',
+      url: '/get_schedule',
+      headers: {
+        // checks if user is authorized to get data
+        Authorization: 'Bearer ' + localStorage.getItem('token'),
+      },
+    })
+      .then((response) => {
+        console.log(response);
+        setScheduledDirecitons(response.data.schedule_result);
+        setErrorMessageSchedule('SCHEDULE RETRIEVED!!');
+      })
+      .catch((error) => {
+        if (error.response) {
+          setErrorMessageSchedule('FAILED TO RETRIEVE SCHEDULE! TRY AGAIN.');
+          console.log(error.response);
+          console.log(error.response.status);
+          console.log(error.response.headers);
+        }
+      });
+  }, []);
+
+  return (
+    <>
+      {scheduledDirections === null ? (
+        <p>You\'re weekly scheduled routes will appear here.</p>
+      ) : (
+        <div>
+          <h2>SCHEDULE LIST GOES HERE</h2>
+          <h3>Monday</h3>
+          <ul>
+            {scheduledDirections.map((route, index) => (
+              <li key={'route_' + index}>{route}</li>
+            ))}
+          </ul>
+          <h3>Tuesday</h3>
+          <h3>Wednesday</h3>
+          <h3>Thursday</h3>
+          <h3>Friday</h3>
+          <h3>Saturday</h3>
+          <h3>Sunday</h3>
+        </div>
+      )}
+    </>
+  );
+};
+export default ScheduleList;


### PR DESCRIPTION
The Profile page now shows the user's saved routes. I know, it still looks like trash right now, but the functionality is all there. The /get_scheduled_directions route in Flask runs a query on the database to gather all routes associated with the current username. This is a join of 2 separate tables, one for the route info and another for the days of the week that the route is needed. The info is passed to the frontend as an array of objects, so every route will have a label for each of its values: 'routeID,' 'origin,' 'destination,' etc. I wrote out its structure in a comment next to the scheduledDirections useState in ScheduleList.js. 

![Screenshot 2023-03-31 at 10 03 50 PM](https://user-images.githubusercontent.com/69475619/229266227-d8e3db95-9034-4a95-8464-918eb70a6bdb.png)

Next steps will obviously be to beautify the visual design of the weekly schedule. Like I said, I would like to make the schedule scrollable from left to right so that it can fit on the Profile page real estate. Also I want to have each route be clickable and populate the map when clicked.

Please look this over and let me know what you think. I'm happy to refactor things or change variable names and stuff if you guys feel like it needs it. 